### PR TITLE
Add missing runtime dependency for Linux Mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [LICENSE](LICENSE).
 
   - For Linux Mint 18 "Sarah" - Cinnamon x64
 
-    `sudo apt install qml-module-qt-labs-settings qml-module-qtgraphicaleffects`
+    `sudo apt install qml-module-qt-labs-settings qml-module-qtgraphicaleffects qml-module-qt-labs-folderlistmodel`
 
   - For Gentoo
 


### PR DESCRIPTION
qml-module-qt-labs-folderlistmodel is missing runtime dependency for Linux Mint 18.3 Cinnamon x64 (builds fine, fails to start). Issue is confirmed on mentioned distro but might also be issue on other Ubuntu based distros. Solution for runtime error was for Ubuntu MATE originally.